### PR TITLE
Add stderr logging

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -472,7 +472,7 @@ class TeeLog(Log):
       with open(os.path.join(tmpdir, 'test-1'), 'rb') as f:
         self.assertEqual(f.read(), b'test')
 
-class FilterLog(Log):
+class FilterMinLog(Log):
 
   @contextlib.contextmanager
   def output_tester(self):
@@ -490,6 +490,67 @@ class FilterLog(Log):
       ('popcontext',),
       ('open', 2, 'same.dat', 'wb', treelog.proto.Level.error),
       ('close', 2, b'test3'),
+      ('write', 'warn', treelog.proto.Level.warning)])
+
+class FilterMaxLog(Log):
+
+  @contextlib.contextmanager
+  def output_tester(self):
+    recordlog = treelog.RecordLog()
+    yield treelog.FilterLog(recordlog, maxlevel=treelog.proto.Level.user)
+    self.assertEqual(recordlog._messages, [
+      ('write', 'my message', treelog.proto.Level.user),
+      ('open', 0, 'test.dat', 'w', treelog.proto.Level.info),
+      ('close', 0, 'test1'),
+      ('pushcontext', 'my context'),
+      ('pushcontext', 'iter 1'),
+      ('write', 'a', treelog.proto.Level.info),
+      ('recontext', 'iter 2'),
+      ('write', 'b', treelog.proto.Level.info),
+      ('recontext', 'iter 3'),
+      ('write', 'c', treelog.proto.Level.info),
+      ('popcontext',),
+      ('open', 1, 'test.dat', 'wb', treelog.proto.Level.user),
+      ('write', 'generating', treelog.proto.Level.info),
+      ('close', 1, b'test2'),
+      ('recontext', 'context step=0'),
+      ('write', 'foo', treelog.proto.Level.info),
+      ('recontext', 'context step=1'),
+      ('write', 'bar', treelog.proto.Level.info),
+      ('popcontext',),
+      ('open', 2, 'dbg.dat', 'wb', treelog.proto.Level.debug),
+      ('close', 2, b'test4'),
+      ('write', 'dbg', treelog.proto.Level.debug)])
+
+class FilterMinMaxLog(Log):
+
+  @contextlib.contextmanager
+  def output_tester(self):
+    recordlog = treelog.RecordLog()
+    yield treelog.FilterLog(recordlog, minlevel=treelog.proto.Level.info, maxlevel=treelog.proto.Level.warning)
+    self.assertEqual(recordlog._messages, [
+      ('write', 'my message', treelog.proto.Level.user),
+      ('open', 0, 'test.dat', 'w', treelog.proto.Level.info),
+      ('close', 0, 'test1'),
+      ('pushcontext', 'my context'),
+      ('pushcontext', 'iter 1'),
+      ('write', 'a', treelog.proto.Level.info),
+      ('recontext', 'iter 2'),
+      ('write', 'b', treelog.proto.Level.info),
+      ('recontext', 'iter 3'),
+      ('write', 'c', treelog.proto.Level.info),
+      ('popcontext',),
+      ('open', 1, 'test.dat', 'wb', treelog.proto.Level.user),
+      ('write', 'generating', treelog.proto.Level.info),
+      ('close', 1, b'test2'),
+      ('recontext', 'generate_test'),
+      ('open', 2, 'test.dat', 'wb', treelog.proto.Level.warning),
+      ('close', 2, b'test3'),
+      ('recontext', 'context step=0'),
+      ('write', 'foo', treelog.proto.Level.info),
+      ('recontext', 'context step=1'),
+      ('write', 'bar', treelog.proto.Level.info),
+      ('popcontext',),
       ('write', 'warn', treelog.proto.Level.warning)])
 
 class LoggingLog(Log):

--- a/tests.py
+++ b/tests.py
@@ -88,6 +88,32 @@ class StdoutLog(Log):
       'dbg.dat\n'
       'dbg\n'
       'warn\n')
+    self.assertEqual(captured.stderr, '')
+
+class StderrLog(Log):
+
+  @contextlib.contextmanager
+  def output_tester(self):
+    with capture() as captured:
+      yield treelog.StderrLog()
+    self.assertEqual(captured.stderr,
+      'my message\n'
+      'test.dat\n'
+      'my context > iter 1 > a\n'
+      'my context > iter 2 > b\n'
+      'my context > iter 3 > c\n'
+      'my context > multiple..\n'
+      '  ..lines\n'
+      'my context > generating\n'
+      'my context > test.dat\n'
+      'generate_test > test.dat\n'
+      'context step=0 > foo\n'
+      'context step=1 > bar\n'
+      'same.dat\n'
+      'dbg.dat\n'
+      'dbg\n'
+      'warn\n')
+    self.assertEqual(captured.stdout, '')
 
 class RichOutputLog(Log):
 
@@ -726,12 +752,14 @@ del Log # hide from unittest discovery
 
 @contextlib.contextmanager
 def capture():
-  with tempfile.TemporaryFile('w+', newline='') as f:
+  with tempfile.TemporaryFile('w+', newline='') as stdout, tempfile.TemporaryFile('w+', newline='') as stderr:
     class captured: pass
-    with contextlib.redirect_stdout(f):
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
       yield captured
-    f.seek(0)
-    captured.stdout = f.read()
+    stdout.seek(0)
+    captured.stdout = stdout.read()
+    stderr.seek(0)
+    captured.stderr = stderr.read()
 
 @contextlib.contextmanager
 def silent():

--- a/treelog/__init__.py
+++ b/treelog/__init__.py
@@ -25,10 +25,10 @@ import sys, functools, contextlib, typing, typing_extensions
 from . import iter, proto
 from ._forward import TeeLog, FilterLog
 from ._silent import NullLog, DataLog, RecordLog
-from ._text import StdoutLog, RichOutputLog, LoggingLog
+from ._text import StdoutLog, StderrLog, RichOutputLog, LoggingLog
 from ._html import HtmlLog
 
-for _log in TeeLog, FilterLog, NullLog, DataLog, RecordLog, StdoutLog, RichOutputLog, LoggingLog, HtmlLog:
+for _log in TeeLog, FilterLog, NullLog, DataLog, RecordLog, StdoutLog, StderrLog, RichOutputLog, LoggingLog, HtmlLog:
   _log.__module__ = __name__
 del _log
 

--- a/treelog/_text.py
+++ b/treelog/_text.py
@@ -66,6 +66,12 @@ class StdoutLog(ContextLog):
   def write(self, text: str, level: proto.Level) -> None:
     print(' > '.join((*self.currentcontext, text)))
 
+class StderrLog(ContextLog):
+  '''Output plain text to stream.'''
+
+  def write(self, text: str, level: proto.Level) -> None:
+    print(' > '.join((*self.currentcontext, text)), file=sys.stderr)
+
 class RichOutputLog(ContextLog):
   '''Output rich (colored,unicode) text to stream.'''
 


### PR DESCRIPTION
This PR allows the conventional filtering of error messages to stderr, and ordinary output to stdout. Essentially it permits the following, which presumably works the same as the current default logger, except it "does the right thing" with error messages.

```python
TeeLog(
    FilterLog(DataLog(), minlevel=proto.Level.info),
    TeeLog(
        FilterLog(StdoutLog(), minlevel=proto.Level.info, maxlevel=proto.Level.user),
        FilterLog(StderrLog(), minlevel=proto.Level.warning),
    )
)
```

I only implemented the functionality, and left the default intact.